### PR TITLE
Add test for S3, database, and redis modules

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: Lint
 
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
     name: Integration test
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 2
       matrix:
-        module: ["s3"]
+        module: ["s3", "database", "redis"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     name: Integration test
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         module: ["s3"]
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Terraform Test
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Integration test
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ["s3"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: terraform test ${{ matrix.module }}
+        working-directory: ${{ matrix.module }}
+        env:
+          CF_USER: ${{ vars.CF_USER }}
+          CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
+        run: terraform test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-cloudgov
 
-Terraform modules for cloud.gov managed services commonly used by [18f/rails-template](https://github.com/18f/rails-template) based apps
+Terraform modules for cloud.gov managed services commonly used by apps running on cloud.gov. This was originally extracted from [18f/rails-template](https://github.com/18f/rails-template) based apps.
 
 ## Module Examples
 
@@ -113,3 +113,7 @@ module "egress_space" {
   ]
 }
 ```
+
+## Testing
+
+We are experimenting with incorporating [`terraform test`](https://developer.hashicorp.com/terraform/language/modules/testing-experiment) into the modules. These tests will run on any open PR.

--- a/database/tests/creation/setup.tf
+++ b/database/tests/creation/setup.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    test = {
+      source = "terraform.io/builtin/test"
+    }
+    cloudfoundry = {
+      source = "cloudfoundry-community/cloudfoundry"
+    }
+  }
+}
+
+# CF_USER and CF_PASSWORD environment variables
+# must be set and have access to local.testing_org/local.testing_space
+provider "cloudfoundry" {
+  api_url = "https://api.fr.cloud.gov"
+}

--- a/database/tests/creation/test_db_creation.tf
+++ b/database/tests/creation/test_db_creation.tf
@@ -1,0 +1,23 @@
+locals {
+  testing_org       = "sandbox-gsa"
+  testing_space     = "ryan.ahearn"
+  testing_plan_name = "micro-psql"
+}
+
+module "main" {
+  source = "../.."
+
+  cf_org_name   = local.testing_org
+  cf_space_name = local.testing_space
+  rds_plan_name = local.testing_plan_name
+  name          = "terraform-cloudgov-db-test"
+}
+
+resource "test_assertions" "instance_id" {
+  component = "instance_id"
+
+  check "guid" {
+    description = "instance_id is a GUID"
+    condition   = can(regex("^\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}$", module.main.instance_id))
+  }
+}

--- a/redis/tests/creation/setup.tf
+++ b/redis/tests/creation/setup.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    test = {
+      source = "terraform.io/builtin/test"
+    }
+    cloudfoundry = {
+      source = "cloudfoundry-community/cloudfoundry"
+    }
+  }
+}
+
+# CF_USER and CF_PASSWORD environment variables
+# must be set and have access to local.testing_org/local.testing_space
+provider "cloudfoundry" {
+  api_url = "https://api.fr.cloud.gov"
+}

--- a/redis/tests/creation/test_redis_creation.tf
+++ b/redis/tests/creation/test_redis_creation.tf
@@ -1,0 +1,23 @@
+locals {
+  testing_org       = "sandbox-gsa"
+  testing_space     = "ryan.ahearn"
+  testing_plan_name = "redis-dev"
+}
+
+module "main" {
+  source = "../.."
+
+  cf_org_name     = local.testing_org
+  cf_space_name   = local.testing_space
+  redis_plan_name = local.testing_plan_name
+  name            = "terraform-cloudgov-redis-test"
+}
+
+resource "test_assertions" "instance_id" {
+  component = "instance_id"
+
+  check "guid" {
+    description = "instance_id is a GUID"
+    condition   = can(regex("^\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}$", module.main.instance_id))
+  }
+}

--- a/redis/variables.tf
+++ b/redis/variables.tf
@@ -22,4 +22,5 @@ variable "recursive_delete" {
 variable "redis_plan_name" {
   type        = string
   description = "name of the service plan name to create"
+  # See options at https://cloud.gov/docs/services/aws-elasticache/#plans
 }

--- a/s3/tests/creation/setup.tf
+++ b/s3/tests/creation/setup.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    test = {
+      source = "terraform.io/builtin/test"
+    }
+    cloudfoundry = {
+      source = "cloudfoundry-community/cloudfoundry"
+    }
+  }
+}
+
+# CF_USER and CF_PASSWORD environment variables
+# must be set and have access to local.testing_org/local.testing_space
+provider "cloudfoundry" {
+  api_url = "https://api.fr.cloud.gov"
+}

--- a/s3/tests/creation/test_bucket_creation.tf
+++ b/s3/tests/creation/test_bucket_creation.tf
@@ -1,0 +1,23 @@
+locals {
+  testing_org       = "sandbox-gsa"
+  testing_space     = "ryan.ahearn"
+  testing_plan_name = "basic-sandbox"
+}
+
+module "main" {
+  source = "../.."
+
+  cf_org_name   = local.testing_org
+  cf_space_name = local.testing_space
+  s3_plan_name  = local.testing_plan_name
+  name          = "terraform-cloudgov-s3-test"
+}
+
+resource "test_assertions" "bucket_id" {
+  component = "bucket_id"
+
+  check "guid" {
+    description = "bucket_id is a GUID"
+    condition   = can(regex("^\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}$", module.main.bucket_id))
+  }
+}


### PR DESCRIPTION
#15 

**Potential issue:** need to be able to actually create the resources, so might not be able to run the bigger / multi-space modules within sandbox-gsa

`cg_space` (permission issues), `clamav` (memory quota too small), and `domain` (relies on manual steps and DNS entries) are all unable to be tested in this manner within `sandbox-gsa`.