### PR TITLE
Ignore secrets.auto.tfvars files that may be used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Local .terraform directories
 **/.terraform/*
 **/.terraform.lock.hcl
+**/secrets.auto.tfvars
 
 # .tfstate files
 *.tfstate

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ module "egress_space" {
 ## Testing
 
 
-> [!WARN]
+> [!WARNING]
 > Tests provision resources in the real world when not using `mock_provider`! Take care that `CF_USER`/`CF_PASSWORD` are set to an account in a suitable non-production space. If other providers, such as the AWS provider, are used, ensure the same care is taken with their credentials in your shell before running `terraform test`.
 
 [Terraform tests](https://developer.hashicorp.com/terraform/language/tests) are in progress of being written. To run for any module with a `tests` directory:

--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ module "egress_space" {
 ## Testing
 
 
-> **Warning**
-Tests provision resources in the real world when not using `mock_provider`! Take care that `CF_USER`/`CF_PASSWORD` are set to an account in a suitable non-production space. If other providers, such as the AWS provider, are used, ensure the same care is taken with their credentials in your shell before running `terraform test`.
+> [!WARN]
+> Tests provision resources in the real world when not using `mock_provider`! Take care that `CF_USER`/`CF_PASSWORD` are set to an account in a suitable non-production space. If other providers, such as the AWS provider, are used, ensure the same care is taken with their credentials in your shell before running `terraform test`.
 
 [Terraform tests](https://developer.hashicorp.com/terraform/language/tests) are in progress of being written. To run for any module with a `tests` directory:
 


### PR DESCRIPTION
nothing fancy, just be sure to ignore any secrets files, which shouldn't be used much in this repo anyway.

also updates the readme warning to use the [github alert syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts)