### PR TITLE
Allow specifying the running security groups for a space

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ module "egress_space" {
   deployers = [
     var.cf_user
   ]
+  asg_names = [
+    "trusted_local_networks_egress",
+    "public_networks_egress"
+  ]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ module "egress_space" {
 }
 ```
 
+> [!WARNING]
+> Any updates to a cg_space module for an already created space will have undesirable cascading effects on services in the space if you are using `depends_on [ module.space_module ]`. Comment out any `depends_on` lines once the space has been initially created.
+
 ### egress_proxy
 
 Creates and configures an instance of cg-egress-proxy to proxy traffic from your apps.

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ module "egress_space" {
     "trusted_local_networks_egress",
     "public_networks_egress"
   ]
+  allow_ssh = false
 }
 ```
 

--- a/cg_space/main.tf
+++ b/cg_space/main.tf
@@ -46,3 +46,21 @@ resource "cloudfoundry_space_users" "space_permissions" {
   managers   = local.manager_ids
   developers = local.developer_ids
 }
+
+###
+# Space Security Groups
+###
+
+data "cloudfoundry_asg" "asgs" {
+  for_each = var.asg_names
+  name     = each.key
+}
+
+locals {
+  asg_ids = [for asg in data.cloudfoundry_asg.asgs : asg.id]
+}
+
+resource "cloudfoundry_space_asgs" "running_security_groups" {
+  space        = cloudfoundry_space.space.id
+  running_asgs = local.asg_ids
+}

--- a/cg_space/main.tf
+++ b/cg_space/main.tf
@@ -3,8 +3,9 @@ data "cloudfoundry_org" "org" {
 }
 
 resource "cloudfoundry_space" "space" {
-  name = var.cf_space_name
-  org  = data.cloudfoundry_org.org.id
+  name      = var.cf_space_name
+  org       = data.cloudfoundry_org.org.id
+  allow_ssh = var.allow_ssh
 }
 
 ###

--- a/cg_space/tests/creation.tftest.hcl
+++ b/cg_space/tests/creation.tftest.hcl
@@ -22,6 +22,7 @@ mock_provider "cloudfoundry" {
 variables {
   cf_org_name   = "gsa-tts-devtools-prototyping"
   cf_space_name = "terraform-cloudgov-ci-tests-egress"
+  asg_names     = ["trusted_local_networks_egress"]
 }
 
 run "test_space_creation" {

--- a/cg_space/variables.tf
+++ b/cg_space/variables.tf
@@ -31,3 +31,9 @@ variable "deployers" {
   description = "list of cloud.gov users to be assigned both SpaceManager and SpaceDeveloper roles"
   default     = []
 }
+
+variable "allow_ssh" {
+  type        = bool
+  description = "(Optional) Allows SSH to application containers via the CF CLI. Defaults to true."
+  default     = true
+}

--- a/cg_space/variables.tf
+++ b/cg_space/variables.tf
@@ -8,6 +8,12 @@ variable "cf_space_name" {
   description = "cloud.gov space name to create"
 }
 
+variable "asg_names" {
+  type        = set(string)
+  description = "list of security group names to apply to the Space"
+  default     = []
+}
+
 variable "managers" {
   type        = set(string)
   description = "list of cloud.gov users to be assigned to the SpaceManager role"


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

# 🎫 Addresses issue: #52 
<!--
Insert the issue number (or full link if the issue is in a different repo
-->
closes #52

## 🛠 Summary of changes

<!--
Write a brief description of what you changed. Bulleted lists are perfect
-->
Enables passing a list of security group names that should be applied to running apps in the space. Default is current behavior of only having `dns` applied.

<!--
## 📜 Testing Plan

How would a peer test this work?

- Step 1
- Step 2
- Step 3
-->

<!--
## 👀 Screenshots and Evidence

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
