### PR TITLE
Switch from mocked tests to real integration tests

### DIFF
--- a/spiffworkflow/main.tf
+++ b/spiffworkflow/main.tf
@@ -30,23 +30,23 @@ data "cloudfoundry_service_plans" "rds" {
   service_offering_name = "aws-rds"
 }
 
-# data "cloudfoundry_org" "org" {
-#   name = var.cf_org_name
-# }
+data "cloudfoundry_org" "org" {
+  name = var.cf_org_name
+}
 
-# data "cloudfoundry_space" "space" {
-#   name = var.cf_space_name
-#   org  = data.cloudfoundry_org.org.id
-# }
+data "cloudfoundry_space" "space" {
+  name = var.cf_space_name
+  org  = data.cloudfoundry_org.org.id
+}
 
-# resource "cloudfoundry_service_instance" "database" {
-#   name         = "${var.app_prefix}-database"
-#   space        = data.cloudfoundry_space.space.id
-#   type         = "managed"
-#   service_plan = data.cloudfoundry_service_plans.rds.service_plans.0.id
-#   tags         = local.tags
-#   parameters   = var.rds_json_params
-# }
+resource "cloudfoundry_service_instance" "database" {
+  name         = "${var.app_prefix}-database"
+  space        = data.cloudfoundry_space.space.id
+  type         = "managed"
+  service_plan = data.cloudfoundry_service_plans.rds.service_plans.0.id
+  tags         = local.tags
+  parameters   = var.rds_json_params
+}
 
 resource "random_uuid" "username" {}
 resource "random_password" "password" {
@@ -97,8 +97,8 @@ resource "cloudfoundry_app" "backend" {
   health_check_type          = "http"
   health_check_http_endpoint = "/api/v1.0/status"
   service_bindings = [
-    # { service_instance = cloudfoundry_service_instance.database.name }
-    { service_instance = var.database_service_instance_id }
+    { service_instance = cloudfoundry_service_instance.database.name }
+    # { service_instance = var.database_service_instance_id }
   ]
   routes = [{
     route    = local.backend_route

--- a/spiffworkflow/tests/creation.tftest.hcl
+++ b/spiffworkflow/tests/creation.tftest.hcl
@@ -1,4 +1,7 @@
-mock_provider "cloudfoundry" {}
+provider "cloudfoundry" {
+  api_url = "https://api.fr.cloud.gov"
+  # cf_user and cf_password are passed in via CF_USER and CF_PASSWORD env vars
+}
 
 variables {
   cf_org_name            = "gsa-tts-devtools-prototyping"

--- a/spiffworkflow/variables.tf
+++ b/spiffworkflow/variables.tf
@@ -123,8 +123,8 @@ variable "frontend_instances" {
   default     = 1
 }
 
-variable "database_service_instance_id" {
-  type = string
-  description = "the service_instance_id of the database to bind to the backend app"
-  default = ""
-}
+# variable "database_service_instance_id" {
+#   type = string
+#   description = "the service_instance_id of the database to bind to the backend app"
+#   default = ""
+# }


### PR DESCRIPTION
<!-- Uncomment and update the sections you need for your PR! -->

# 🎫 Addresses issue: no issue
<!--
Insert the issue number (or full link if the issue is in a different repo
-->

## 🛠 Summary of changes

<!--
Write a brief description of what you changed. Bulleted lists are perfect
-->
* switch from using `mock_provider` to real provider because I can't figure out how to properly mock out `data.cloudfoundry_service_plans` in a way that makes terraform happy

this causes the test to take about 10 minutes, which is probably too long. We could [override the most expensive resources](https://github.com/GSA-TTS/terraform-cloudgov/blob/206ee1a196406a9f29a08aef57da88552400752b/database/tests/creation.tftest.hcl#L18-L23) to bring that back down while keeping the real provider in use.

<!--
## 📜 Testing Plan

How would a peer test this work?

- Step 1
- Step 2
- Step 3
-->

<!--
## 👀 Screenshots and Evidence

If relevant, include a screenshot or screen capture of the changes.

<details>
<summary>Before:</summary>

</details>

<details>
<summary>After:</summary>

</details>
-->
