### PR TITLE
Protect against globbing/splitting

### DIFF
--- a/egress_proxy/prepare-proxy.sh
+++ b/egress_proxy/prepare-proxy.sh
@@ -5,7 +5,7 @@ set -e
 
 eval "$(jq -r '@sh "GITREF=\(.gitref)"')"
 
-popdir=$(pwd)
+popdir="$(pwd)"
 
 # Portable construct so this will work everywhere
 # https://unix.stackexchange.com/a/84980
@@ -13,11 +13,11 @@ tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
 cd "$tmpdir"
 
 # Grab a copy of the zip file for the specified ref
-curl -s -L https://github.com/GSA-TTS/cg-egress-proxy/archive/${GITREF}.zip --output local.zip
+curl -s -L "https://github.com/GSA-TTS/cg-egress-proxy/archive/${GITREF}.zip" --output local.zip
 
 # Zip up just the proxy/ subdirectory for pushing
 unzip -q -u local.zip \*/proxy/\*
-zip -q -j -r ${popdir}/proxy.zip cg-egress-proxy-*/proxy
+zip -q -j -r "${popdir}"/proxy.zip cg-egress-proxy-*/proxy
 
 # Tell Terraform where to find it
 cat << EOF


### PR DESCRIPTION
### No Issue

Fix: 
- Protects against globbing. I am starting to upgrade the FAC and am referencing the egress module in our sandbox environment. Since I am running on WSL2, with a `" "` in my path of execution on `mnt` (not my call), the proxy build will fail due to the path being split. 
ex: `/mnt/c/Users/Alex Steel/Code/FAC/terraform/sandbox/.terraform/../../egress_proxy/proxy.zip` where the .terraform gets split at `/mnt/c/Users/Alex` and breaks the sh.