### PR TITLE
Output the database name

### DIFF
--- a/database/outputs.tf
+++ b/database/outputs.tf
@@ -1,3 +1,7 @@
 output "instance_id" {
   value = cloudfoundry_service_instance.rds.id
 }
+
+output "database_name" {
+  value = cloudfoundry_service_instance.rds.name
+}


### PR DESCRIPTION
## No Issue

## Addition:
Adds `database_name` to outputs for the database module. Would be nice to use the modules output for service bindings
```tf
service_bindings = {
  "${module.database.database_name}" = ""
}
```

Tested with `terraform refresh` and `terraform output database_name`
```tf
# terraform refresh 
[...]
Outputs:

database_name = "test"

[12:45 PM][asteel][database]$ terraform output database_name
"test"
[12:46 PM][asteel][database]$
```