### PR TITLE
Add a note about the proxy and new relic in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ Creates and configures an instance of cg-egress-proxy to proxy traffic from your
 
 Prerequite: existing public-egress space to deploy the proxy into
 
+> [!NOTE]
+> It may be necessary to use the `allowports` variable to allow new relic agents to communicate through the proxy to the collector. This was discovered on the FAC who uses the python new relic agent, and giving the module `allowports = [443, 61443]` allowed the agent to successfully communicate with the FEDRAMP'd `gov-collector.newrelic.com` endpoint for telemetry.
+
 ```
 module "egress_proxy" {
   source = "github.com/GSA-TTS/terraform-cloudgov//egress_proxy?ref=v2.3.0"


### PR DESCRIPTION
## No Issue
Updates the readme for the proxy to include findings from when the FAC upgraded to the module. We use a python new relic agent on the instance to send telemetry along with the logshipper, and when we deployed, we noticed that all traffic was successfully going through the proxy, except for the new relic agent. Allowing both 443 and 61443 fixed the issue, presumably due to the `https_uri` and the new relic agent having the `:61443` port for the proxy string. 

Not setting this as a default, just an addition to the readme as some teams may not want 61443 forced by default.