### PR TITLE
Update to remove init process

### DIFF
--- a/spiffworkflow/build-backend.sh
+++ b/spiffworkflow/build-backend.sh
@@ -355,6 +355,12 @@ echo "Process models copied to: ${PROCESS_MODELS_DEST}"
 echo "Removing any .bpmn.png files from process models directory..."
 find "${PROCESS_MODELS_DEST}" -type f -name "*.bpmn.png" -delete
 
+# Ensure we run the bootstrap process model, if it exists at all, on only one app instance
+if [[ "${CF_INSTANCE_INDEX:-0}" != "0" ]]; then
+  echo "Skipping the bootstrap script for app instance at index ${CF_INSTANCE_INDEX} by unsetting SPIFFWORKFLOW_BACKEND_BOOTSTRAP_PROCESS_MODEL"
+  unset SPIFFWORKFLOW_BACKEND_BOOTSTRAP_PROCESS_MODEL
+fi
+
 # Generate requirements.txt from uv.lock
 echo "Generating requirements.txt from uv files..."
 if [ -f "${BACKEND_DIR}/uv.lock" ] && [ -f "${BACKEND_DIR}/pyproject.toml" ]; then

--- a/spiffworkflow/build-backend.sh
+++ b/spiffworkflow/build-backend.sh
@@ -355,10 +355,21 @@ echo "Process models copied to: ${PROCESS_MODELS_DEST}"
 echo "Removing any .bpmn.png files from process models directory..."
 find "${PROCESS_MODELS_DEST}" -type f -name "*.bpmn.png" -delete
 
-# Ensure we run the bootstrap process model, if it exists at all, on only one app instance
-if [[ "${CF_INSTANCE_INDEX:-0}" != "0" ]]; then
-  echo "Skipping the bootstrap script for app instance at index ${CF_INSTANCE_INDEX} by unsetting SPIFFWORKFLOW_BACKEND_BOOTSTRAP_PROCESS_MODEL"
-  unset SPIFFWORKFLOW_BACKEND_BOOTSTRAP_PROCESS_MODEL
+# ----------------------------------------------------------------------------
+# Include content of custom scripts directory (eg profile hooks)
+# Note these are copied relative to the root of the application!
+# ----------------------------------------------------------------------------
+if [ -n "${BACKEND_SCRIPTS_PATH}" ] && [ -d "${BACKEND_SCRIPTS_PATH}" ]; then
+  echo "Including custom scripts from ${BACKEND_SCRIPTS_PATH} ..."
+  cp -R "${BACKEND_SCRIPTS_PATH}/." "${BACKEND_DIR}/"
+  if ls "${BACKEND_DIR}/.profile.d"/*.sh >/dev/null 2>&1; then
+    echo "Found profile hook scripts:"
+    ls -1 "${BACKEND_DIR}/.profile.d"/*.sh || true
+  else
+    echo "No .profile.d hook scripts found in scripts directory (optional)."
+  fi
+else
+  echo "Scripts path not present or not a directory: ${BACKEND_SCRIPTS_PATH} (skipping script vendoring)"
 fi
 
 # Generate requirements.txt from uv.lock


### PR DESCRIPTION
[This PR](https://github.com/GSA-TTS/terraform-cloudgov/pull/97) (merged into the stable branch) worked, but there were no guards for multi-instance deployments; in other words, multiple instances would run the bootstrap process model on startup. To handle this:

1. We add the .profile.d script directory back into the `build-backend.sh` in this PR.
2. PIC-side, in a .profile.d script, we have a script to unset the bootstrap environment variable if the `CF_INSTANCE_INDEX` is not 0.