### PR TITLE
Add prevent_destroy lifecycle option to the database resource

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -64,6 +64,46 @@ Follow the steps in the [cloudfoundry provider migration guide](https://github.c
 1. Run: `terraform import module.database.cloudfoundry_service_instance.rds ID_FROM_STEP_3`
 1. Run: `terraform apply` to fill in new computed attributes
 
+## Database: `prevent_destroy` support
+
+The database module now supports a `prevent_destroy` variable (default: `false`) that prevents accidental destruction of the database service instance.
+
+### Upgrading existing databases (default behavior, `prevent_destroy = false`)
+
+No action required. The module includes a `moved` block that automatically migrates state from `cloudfoundry_service_instance.rds` to `cloudfoundry_service_instance.rds[0]`. Run `terraform plan` and verify you see only a state address change with zero infrastructure modifications, then `terraform apply`.
+
+### Enabling protection on an existing database (`prevent_destroy = true`)
+
+> ⚠️ **WARNING:** You **must** perform the manual state move below **before** running `terraform plan`. If you skip this step, Terraform will plan to **destroy** the existing database and create a new one. The `terraform plan` output will clearly show `1 to destroy, 1 to add` — always review plans carefully.
+
+1. Update your module source ref to the new version.
+2. Set `prevent_destroy = true` in your module call.
+3. **Before running `terraform plan`**, move the state (replace `<NAME>` with your module's name, e.g., `workflow-db`, `database`):
+
+    ```bash
+    terraform state mv \
+      'module.<NAME>.cloudfoundry_service_instance.rds' \
+      'module.<NAME>.cloudfoundry_service_instance.rds_protected[0]'
+    ```
+
+4. Run `terraform plan` and confirm zero infrastructure changes.
+5. Run `terraform apply`.
+
+### Enabling protection on a database that already upgraded with the default
+
+If you previously upgraded with `prevent_destroy = false` (the default) and later want to enable protection:
+
+1. Set `prevent_destroy = true` in your module call.
+2. Move the state:
+
+    ```bash
+    terraform state mv \
+      'module.<NAME>.cloudfoundry_service_instance.rds[0]' \
+      'module.<NAME>.cloudfoundry_service_instance.rds_protected[0]'
+    ```
+
+3. Run `terraform plan`, confirm zero changes, and `terraform apply`.
+
 ## Module Changes
 
 ### Common Changes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -68,33 +68,21 @@ Follow the steps in the [cloudfoundry provider migration guide](https://github.c
 
 The database module now supports a `prevent_destroy` variable (default: `false`) that prevents accidental destruction of the database service instance.
 
-### Upgrading existing databases (default behavior, `prevent_destroy = false`)
+### Step 1: Upgrade to the new module version
 
-No action required. The module includes a `moved` block that automatically migrates state from `cloudfoundry_service_instance.rds` to `cloudfoundry_service_instance.rds[0]`. Run `terraform plan` and verify you see only a state address change with zero infrastructure modifications, then `terraform apply`.
+This step is the same for everyone. Update your module source ref to the new version and run:
 
-### Enabling protection on an existing database (`prevent_destroy = true`)
+1. `terraform plan` — verify you see only a state address rename (`cloudfoundry_service_instance.rds` → `cloudfoundry_service_instance.rds[0]`) with zero infrastructure changes.
+2. `terraform apply`.
 
-> ⚠️ **WARNING:** You **must** perform the manual state move below **before** running `terraform plan`. If you skip this step, Terraform will plan to **destroy** the existing database and create a new one. The `terraform plan` output will clearly show `1 to destroy, 1 to add` — always review plans carefully.
+### Step 2 (optional): Enable `prevent_destroy`
 
-1. Update your module source ref to the new version.
-2. Set `prevent_destroy = true` in your module call.
-3. **Before running `terraform plan`**, move the state (replace `<NAME>` with your module's name, e.g., `workflow-db`, `database`):
+If you want to protect a database from accidental destruction, perform this step after completing Step 1.
 
-    ```bash
-    terraform state mv \
-      'module.<NAME>.cloudfoundry_service_instance.rds' \
-      'module.<NAME>.cloudfoundry_service_instance.rds_protected[0]'
-    ```
-
-4. Run `terraform plan` and confirm zero infrastructure changes.
-5. Run `terraform apply`.
-
-### Enabling protection on a database that already upgraded with the default
-
-If you previously upgraded with `prevent_destroy = false` (the default) and later want to enable protection:
+> ⚠️ **WARNING:** You **must** perform the state move below **before** running `terraform plan`. If you skip it, Terraform will plan to **destroy** the existing database and create a new one. `terraform plan` should clearly show `0 to destroy` if you've done the move correctly — always review plans carefully.
 
 1. Set `prevent_destroy = true` in your module call.
-2. Move the state:
+2. Move the state (replace `<NAME>` with your module's name, e.g., `workflow-db`, `database`):
 
     ```bash
     terraform state mv \
@@ -102,7 +90,8 @@ If you previously upgraded with `prevent_destroy = false` (the default) and late
       'module.<NAME>.cloudfoundry_service_instance.rds_protected[0]'
     ```
 
-3. Run `terraform plan`, confirm zero changes, and `terraform apply`.
+3. Run `terraform plan` and confirm zero infrastructure changes.
+4. Run `terraform apply`.
 
 ## Module Changes
 

--- a/cg_space/tests/creation.tftest.hcl
+++ b/cg_space/tests/creation.tftest.hcl
@@ -1,43 +1,5 @@
 provider "cloudfoundry" {}
 
-override_data {
-  target = data.cloudfoundry_org.org
-  values = {
-    id = "591a8a56-3093-43e7-a21e-1b1b4dbd1c3a"
-  }
-}
-
-override_data {
-  target = data.cloudfoundry_security_group.security_groups
-  values = {
-    id = "b2c3d4e5-f6a7-8901-bcde-f12345678901"
-  }
-}
-
-override_resource {
-  target = cloudfoundry_space.space
-  values = {
-    id   = "31a2c21d-ba50-437b-9d40-8c2d741af9e7"
-    name = "terraform-cloudgov-tf-tests-egress"
-  }
-}
-
-override_resource {
-  target = cloudfoundry_space_role.managers
-}
-
-override_resource {
-  target = cloudfoundry_space_role.developers
-}
-
-override_resource {
-  target = cloudfoundry_space_role.auditors
-}
-
-override_resource {
-  target = cloudfoundry_security_group_space_bindings.security_group_bindings
-}
-
 variables {
   cf_org_name   = "cloud-gov-devtools-development"
   cf_space_name = "terraform-cloudgov-tf-tests-egress"

--- a/cg_space/tests/creation.tftest.hcl
+++ b/cg_space/tests/creation.tftest.hcl
@@ -1,5 +1,43 @@
 provider "cloudfoundry" {}
 
+override_data {
+  target = data.cloudfoundry_org.org
+  values = {
+    id = "591a8a56-3093-43e7-a21e-1b1b4dbd1c3a"
+  }
+}
+
+override_data {
+  target = data.cloudfoundry_security_group.security_groups
+  values = {
+    id = "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+  }
+}
+
+override_resource {
+  target = cloudfoundry_space.space
+  values = {
+    id   = "31a2c21d-ba50-437b-9d40-8c2d741af9e7"
+    name = "terraform-cloudgov-tf-tests-egress"
+  }
+}
+
+override_resource {
+  target = cloudfoundry_space_role.managers
+}
+
+override_resource {
+  target = cloudfoundry_space_role.developers
+}
+
+override_resource {
+  target = cloudfoundry_space_role.auditors
+}
+
+override_resource {
+  target = cloudfoundry_security_group_space_bindings.security_group_bindings
+}
+
 variables {
   cf_org_name   = "cloud-gov-devtools-development"
   cf_space_name = "terraform-cloudgov-tf-tests-egress"

--- a/database/main.tf
+++ b/database/main.tf
@@ -7,10 +7,6 @@ data "cloudfoundry_service_plans" "rds" {
   service_offering_name = "aws-rds"
 }
 
-resource "prevent_destroy_rds" "trigger" {
-  input = var.prevent_destroy
-}
-
 resource "cloudfoundry_service_instance" "rds" {
   name         = var.name
   space        = var.cf_space_id

--- a/database/main.tf
+++ b/database/main.tf
@@ -20,6 +20,6 @@ resource "cloudfoundry_service_instance" "rds" {
   parameters   = var.json_params
 
   lifecycle {
-    prevent_destroy = [prevent_destroy_rds.trigger]
+    prevent_destroy = true
   }
 }

--- a/database/main.tf
+++ b/database/main.tf
@@ -14,4 +14,8 @@ resource "cloudfoundry_service_instance" "rds" {
   service_plan = data.cloudfoundry_service_plans.rds.service_plans.0.id
   tags         = local.tags
   parameters   = var.json_params
+
+  lifecycle {
+    prevent_destroy = var.prevent_destroy
+  }
 }

--- a/database/main.tf
+++ b/database/main.tf
@@ -7,6 +7,10 @@ data "cloudfoundry_service_plans" "rds" {
   service_offering_name = "aws-rds"
 }
 
+resource "prevent_destroy_rds" "trigger" {
+  input = var.prevent_destroy
+}
+
 resource "cloudfoundry_service_instance" "rds" {
   name         = var.name
   space        = var.cf_space_id
@@ -16,6 +20,6 @@ resource "cloudfoundry_service_instance" "rds" {
   parameters   = var.json_params
 
   lifecycle {
-    prevent_destroy = var.prevent_destroy
+    prevent_destroy = [prevent_destroy_rds.trigger]
   }
 }

--- a/database/main.tf
+++ b/database/main.tf
@@ -8,6 +8,17 @@ data "cloudfoundry_service_plans" "rds" {
 }
 
 resource "cloudfoundry_service_instance" "rds" {
+  count        = var.prevent_destroy ? 0 : 1
+  name         = var.name
+  space        = var.cf_space_id
+  type         = "managed"
+  service_plan = data.cloudfoundry_service_plans.rds.service_plans.0.id
+  tags         = local.tags
+  parameters   = var.json_params
+}
+
+resource "cloudfoundry_service_instance" "rds_protected" {
+  count        = var.prevent_destroy ? 1 : 0
   name         = var.name
   space        = var.cf_space_id
   type         = "managed"
@@ -18,4 +29,16 @@ resource "cloudfoundry_service_instance" "rds" {
   lifecycle {
     prevent_destroy = true
   }
+}
+
+# Automatically migrate existing state for the default (prevent_destroy = false)
+# upgrade path. Previously the resource had no count; adding count requires moving
+# from the unindexed address to [0]. Without this block, Terraform would plan to
+# destroy the existing instance and create a new one.
+#
+# If setting prevent_destroy = true on an existing database, you must manually run
+# `terraform state mv` BEFORE planning. See UPGRADING.md for details.
+moved {
+  from = cloudfoundry_service_instance.rds
+  to   = cloudfoundry_service_instance.rds[0]
 }

--- a/database/main.tf
+++ b/database/main.tf
@@ -37,7 +37,8 @@ resource "cloudfoundry_service_instance" "rds_protected" {
 # destroy the existing instance and create a new one.
 #
 # If setting prevent_destroy = true on an existing database, you must manually run
-# `terraform state mv` BEFORE planning. See UPGRADING.md for details.
+# `terraform state mv` BEFORE planning. See UPGRADING.md for details:
+# https://github.com/GSA-TTS/terraform-cloudgov/blob/main/UPGRADING.md#database-prevent_destroy-support
 moved {
   from = cloudfoundry_service_instance.rds
   to   = cloudfoundry_service_instance.rds[0]

--- a/database/outputs.tf
+++ b/database/outputs.tf
@@ -1,7 +1,7 @@
 output "instance_id" {
-  value = cloudfoundry_service_instance.rds.id
+  value = var.prevent_destroy ? cloudfoundry_service_instance.rds_protected[0].id : cloudfoundry_service_instance.rds[0].id
 }
 
 output "database_name" {
-  value = cloudfoundry_service_instance.rds.name
+  value = var.prevent_destroy ? cloudfoundry_service_instance.rds_protected[0].name : cloudfoundry_service_instance.rds[0].name
 }

--- a/database/tests/creation.tftest.hcl
+++ b/database/tests/creation.tftest.hcl
@@ -13,34 +13,72 @@ variables {
 
 run "test_db_creation" {
   override_resource {
-    target = cloudfoundry_service_instance.rds
+    target = cloudfoundry_service_instance.rds[0]
     values = {
       id = "f6925fad-f9e8-4c93-b69f-132438f6a2f4"
     }
   }
 
   assert {
-    condition     = cloudfoundry_service_instance.rds.id == output.instance_id
+    condition     = cloudfoundry_service_instance.rds[0].id == output.instance_id
     error_message = "Instance ID output must match the service instance"
   }
 
   assert {
-    condition     = cloudfoundry_service_instance.rds.service_plan == data.cloudfoundry_service_plans.rds.service_plans.0.id
+    condition     = cloudfoundry_service_instance.rds[0].service_plan == data.cloudfoundry_service_plans.rds.service_plans.0.id
     error_message = "Service Plan should match the rds_plan_name variable"
   }
 
   assert {
-    condition     = cloudfoundry_service_instance.rds.name == var.name
+    condition     = cloudfoundry_service_instance.rds[0].name == var.name
     error_message = "Service instance name should match the name variable"
   }
 
   assert {
-    condition     = cloudfoundry_service_instance.rds.tags == tolist(var.tags)
+    condition     = cloudfoundry_service_instance.rds[0].tags == tolist(var.tags)
     error_message = "Service instance tags should match the tags variable"
   }
 
   assert {
-    condition     = cloudfoundry_service_instance.rds.parameters == "{\"backup_retention_period\":30}"
+    condition     = cloudfoundry_service_instance.rds[0].parameters == "{\"backup_retention_period\":30}"
+    error_message = "Service instance json_params should be configurable"
+  }
+}
+
+run "test_protected_db_creation" {
+  variables {
+    prevent_destroy = true
+  }
+
+  override_resource {
+    target = cloudfoundry_service_instance.rds_protected[0]
+    values = {
+      id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    }
+  }
+
+  assert {
+    condition     = cloudfoundry_service_instance.rds_protected[0].id == output.instance_id
+    error_message = "Instance ID output must match the protected service instance"
+  }
+
+  assert {
+    condition     = cloudfoundry_service_instance.rds_protected[0].service_plan == data.cloudfoundry_service_plans.rds.service_plans.0.id
+    error_message = "Service Plan should match the rds_plan_name variable"
+  }
+
+  assert {
+    condition     = cloudfoundry_service_instance.rds_protected[0].name == var.name
+    error_message = "Service instance name should match the name variable"
+  }
+
+  assert {
+    condition     = cloudfoundry_service_instance.rds_protected[0].tags == tolist(var.tags)
+    error_message = "Service instance tags should match the tags variable"
+  }
+
+  assert {
+    condition     = cloudfoundry_service_instance.rds_protected[0].parameters == "{\"backup_retention_period\":30}"
     error_message = "Service instance json_params should be configurable"
   }
 }

--- a/database/variables.tf
+++ b/database/variables.tf
@@ -26,9 +26,3 @@ variable "json_params" {
   default     = null
   # See options at https://cloud.gov/docs/services/relational-database/#setting-optional-parameters-1
 }
-
-variable "prevent_destroy" {
-  description = "Whether or not to set this resource as protected"
-  type        = bool
-  default     = false
-}

--- a/database/variables.tf
+++ b/database/variables.tf
@@ -26,3 +26,9 @@ variable "json_params" {
   default     = null
   # See options at https://cloud.gov/docs/services/relational-database/#setting-optional-parameters-1
 }
+
+variable "prevent_destroy" {
+  description = "Whether or not to set this resource as protected"
+  type        = bool
+  default     = false
+}

--- a/database/variables.tf
+++ b/database/variables.tf
@@ -33,7 +33,8 @@ variable "prevent_destroy" {
     production or other persistent environments.
 
     IMPORTANT: Enabling this on an existing database requires a manual state
-    migration step BEFORE running terraform plan. See UPGRADING.md for details.
+    migration step BEFORE running terraform plan. See UPGRADING.md for details:
+    https://github.com/GSA-TTS/terraform-cloudgov/blob/main/UPGRADING.md#database-prevent_destroy-support
   EOT
   type        = bool
   default     = false

--- a/database/variables.tf
+++ b/database/variables.tf
@@ -26,3 +26,15 @@ variable "json_params" {
   default     = null
   # See options at https://cloud.gov/docs/services/relational-database/#setting-optional-parameters-1
 }
+
+variable "prevent_destroy" {
+  description = <<-EOT
+    Prevent accidental destruction of the database instance. Set to true for
+    production or other persistent environments.
+
+    IMPORTANT: Enabling this on an existing database requires a manual state
+    migration step BEFORE running terraform plan. See UPGRADING.md for details.
+  EOT
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
We have accidentally deleted an RDS resource twice and want to avoid that in the future. This seems like the best way to do so.