### PR TITLE
Make resource dependencies in client code more explicit and simpler to read

### DIFF
--- a/app_route/main.tf
+++ b/app_route/main.tf
@@ -1,9 +1,18 @@
+check "deprecated_space_vars" {
+  assert {
+    condition     = var.cf_org_name == "" && var.cf_space_name == ""
+    error_message = "The cf_org_name and cf_space_name variables are deprecated. Use the `space` variable instead to pass a cloudfoundry_space resource directly."
+  }
+}
+
 data "cloudfoundry_org" "org" {
-  name = var.cf_org_name
+  count = var.space == null ? 1 : 0
+  name  = var.cf_org_name
 }
 data "cloudfoundry_space" "space" {
-  name = var.cf_space_name
-  org  = data.cloudfoundry_org.org.id
+  count = var.space == null ? 1 : 0
+  name  = var.cf_space_name
+  org   = data.cloudfoundry_org.org[0].id
 }
 
 data "cloudfoundry_domain" "domain" {
@@ -11,13 +20,14 @@ data "cloudfoundry_domain" "domain" {
 }
 
 locals {
+  space_id = var.space != null ? var.space.id : data.cloudfoundry_space.space[0].id
   destinations = (length(var.app_ids) == 0 ? null : [
     for dest in var.app_ids : { app_id = dest }
   ])
 }
 resource "cloudfoundry_route" "app_route" {
   domain = data.cloudfoundry_domain.domain.id
-  space  = data.cloudfoundry_space.space.id
+  space  = local.space_id
   host   = var.hostname
   path   = var.path
 

--- a/app_route/tests/creation.tftest.hcl
+++ b/app_route/tests/creation.tftest.hcl
@@ -17,15 +17,22 @@ mock_provider "cloudfoundry" {
 }
 
 variables {
-  cf_org_name   = "cloud-gov-devtools-development"
-  cf_space_name = "terraform-cloudgov-tf-tests"
-  app_ids       = ["731ed210-af91-4e05-886e-a2fbaf5125cb"]
-  hostname      = "my-host"
-  domain        = "apps.internal"
+  space = {
+    id = "31a2c21d-ba50-437b-9d40-8c2d741af9e7"
+  }
+  app_ids  = ["731ed210-af91-4e05-886e-a2fbaf5125cb"]
+  hostname = "my-host"
+  domain   = "apps.internal"
 }
 
-run "test_route_creation" {
+run "test_route_creation_deprecated" {
   command = plan
+
+  variables {
+    cf_org_name   = "cloud-gov-devtools-development"
+    cf_space_name = "terraform-cloudgov-tf-tests"
+    space         = null
+  }
 
   expect_failures = [
     check.deprecated_space_vars
@@ -42,13 +49,10 @@ run "test_route_creation" {
   }
 }
 
-run "test_route_creation_with_space_object" {
+run "test_route_creation" {
   variables {
     cf_org_name   = ""
     cf_space_name = ""
-    space = {
-      id = "31a2c21d-ba50-437b-9d40-8c2d741af9e7"
-    }
   }
 
   assert {

--- a/app_route/tests/creation.tftest.hcl
+++ b/app_route/tests/creation.tftest.hcl
@@ -37,16 +37,6 @@ run "test_route_creation_deprecated" {
   expect_failures = [
     check.deprecated_space_vars
   ]
-
-  assert {
-    condition     = output.endpoint == cloudfoundry_route.app_route.url
-    error_message = "The route URL should be in the output"
-  }
-
-  assert {
-    condition     = output.route_id == cloudfoundry_route.app_route.id
-    error_message = "The route's ID is in the output"
-  }
 }
 
 run "test_route_creation" {

--- a/app_route/tests/creation.tftest.hcl
+++ b/app_route/tests/creation.tftest.hcl
@@ -25,6 +25,12 @@ variables {
 }
 
 run "test_route_creation" {
+  command = plan
+
+  expect_failures = [
+    check.deprecated_space_vars
+  ]
+
   assert {
     condition     = output.endpoint == cloudfoundry_route.app_route.url
     error_message = "The route URL should be in the output"
@@ -41,12 +47,8 @@ run "test_route_creation_with_space_object" {
     cf_org_name   = ""
     cf_space_name = ""
     space = {
-      id   = "31a2c21d-ba50-437b-9d40-8c2d741af9e7"
-      name = "terraform-cloudgov-tf-tests"
+      id = "31a2c21d-ba50-437b-9d40-8c2d741af9e7"
     }
-    app_ids  = ["731ed210-af91-4e05-886e-a2fbaf5125cb"]
-    hostname = "my-host"
-    domain   = "apps.internal"
   }
 
   assert {
@@ -59,3 +61,4 @@ run "test_route_creation_with_space_object" {
     error_message = "The route's ID is in the output"
   }
 }
+

--- a/app_route/tests/creation.tftest.hcl
+++ b/app_route/tests/creation.tftest.hcl
@@ -35,3 +35,27 @@ run "test_route_creation" {
     error_message = "The route's ID is in the output"
   }
 }
+
+run "test_route_creation_with_space_object" {
+  variables {
+    cf_org_name   = ""
+    cf_space_name = ""
+    space = {
+      id   = "31a2c21d-ba50-437b-9d40-8c2d741af9e7"
+      name = "terraform-cloudgov-tf-tests"
+    }
+    app_ids  = ["731ed210-af91-4e05-886e-a2fbaf5125cb"]
+    hostname = "my-host"
+    domain   = "apps.internal"
+  }
+
+  assert {
+    condition     = output.endpoint == cloudfoundry_route.app_route.url
+    error_message = "The route URL should be in the output"
+  }
+
+  assert {
+    condition     = output.route_id == cloudfoundry_route.app_route.id
+    error_message = "The route's ID is in the output"
+  }
+}

--- a/app_route/variables.tf
+++ b/app_route/variables.tf
@@ -1,11 +1,21 @@
 variable "cf_org_name" {
   type        = string
-  description = "cloud.gov organization name"
+  description = "cloud.gov organization name (deprecated; use `space` instead.)"
+  default     = ""
 }
 
 variable "cf_space_name" {
   type        = string
-  description = "cloud.gov space name"
+  description = "cloud.gov space name (deprecated; use `space` instead.)"
+  default     = ""
+}
+
+variable "space" {
+  type = object({
+    id = string
+  })
+  description = "A cloudfoundry_space resource (or any object with .id). When provided, cf_org_name and cf_space_name are not used."
+  default     = null
 }
 
 variable "app_ids" {

--- a/application/main.tf
+++ b/application/main.tf
@@ -9,9 +9,20 @@ data "external" "app_zip" {
   }
 }
 
+check "deprecated_cf_space_name" {
+  assert {
+    condition     = var.cf_space_name == ""
+    error_message = "The cf_space_name variable is deprecated. Use the `space` variable instead to pass a cloudfoundry_space resource directly."
+  }
+}
+
+locals {
+  space_name = var.space != null ? var.space.name : var.cf_space_name
+}
+
 resource "cloudfoundry_app" "application" {
   name       = var.name
-  space_name = var.cf_space_name
+  space_name = local.space_name
   org_name   = var.cf_org_name
 
   path             = "${path.module}/${data.external.app_zip.result.path}"
@@ -37,9 +48,8 @@ resource "cloudfoundry_app" "application" {
 module "route" {
   source = "../app_route"
 
-  cf_org_name   = var.cf_org_name
-  cf_space_name = var.cf_space_name
-  domain        = var.domain
-  hostname      = coalesce(var.hostname, var.name)
-  app_ids       = [cloudfoundry_app.application.id]
+  space    = var.space
+  domain   = var.domain
+  hostname = coalesce(var.hostname, var.name)
+  app_ids  = [cloudfoundry_app.application.id]
 }

--- a/application/main.tf
+++ b/application/main.tf
@@ -16,14 +16,35 @@ check "deprecated_cf_space_name" {
   }
 }
 
+data "cloudfoundry_org" "org" {
+  count = var.space == null ? 1 : 0
+  name  = var.cf_org_name
+}
+
+data "cloudfoundry_space" "space" {
+  count = var.space == null ? 1 : 0
+  name  = var.cf_space_name
+  org   = data.cloudfoundry_org.org[0].id
+}
+
 locals {
-  space_name = var.space != null ? var.space.name : var.cf_space_name
+  space = var.space != null ? var.space : {
+    id   = data.cloudfoundry_space.space[0].id
+    name = var.cf_space_name
+  }
 }
 
 resource "cloudfoundry_app" "application" {
   name       = var.name
-  space_name = local.space_name
+  space_name = local.space.name
   org_name   = var.cf_org_name
+
+  lifecycle {
+    precondition {
+      condition     = var.space != null || var.cf_space_name != ""
+      error_message = "You must provide either the `space` variable or the deprecated `cf_space_name` variable."
+    }
+  }
 
   path             = "${path.module}/${data.external.app_zip.result.path}"
   source_code_hash = filesha256("${path.module}/${data.external.app_zip.result.path}")
@@ -48,7 +69,7 @@ resource "cloudfoundry_app" "application" {
 module "route" {
   source = "../app_route"
 
-  space    = var.space
+  space    = local.space
   domain   = var.domain
   hostname = coalesce(var.hostname, var.name)
   app_ids  = [cloudfoundry_app.application.id]

--- a/application/tests/creation.tftest.hcl
+++ b/application/tests/creation.tftest.hcl
@@ -1,24 +1,17 @@
 mock_provider "cloudfoundry" {
-  mock_data "cloudfoundry_org" {
-    defaults = {
-      id = "591a8a56-3093-43e7-a21e-1b1b4dbd1c3a"
-    }
-  }
   mock_data "cloudfoundry_domain" {
     defaults = {
       id = "ad9f5303-b5b0-40cb-b21a-a7276efae4b1"
     }
   }
-  mock_data "cloudfoundry_space" {
-    defaults = {
-      id = "31a2c21d-ba50-437b-9d40-8c2d741af9e7"
-    }
-  }
 }
 
 variables {
-  cf_org_name          = "cloud-gov-devtools-development"
-  cf_space_name        = "terraform-cloudgov-tf-tests"
+  cf_org_name = "cloud-gov-devtools-development"
+  space = {
+    id   = "31a2c21d-ba50-437b-9d40-8c2d741af9e7"
+    name = "terraform-cloudgov-tf-tests"
+  }
   name                 = "fac-app"
   github_org_name      = "gsa-tts"
   github_repo_name     = "fac"
@@ -44,6 +37,19 @@ variables {
     ENV_VAR  = "1"
     ENV_VAR2 = "2"
   }
+}
+
+run "application_tests_deprecated" {
+  command = plan
+
+  variables {
+    cf_space_name = "terraform-cloudgov-tf-tests"
+    space         = null
+  }
+
+  expect_failures = [
+    check.deprecated_cf_space_name
+  ]
 }
 
 run "application_tests" {

--- a/application/tests/creation.tftest.hcl
+++ b/application/tests/creation.tftest.hcl
@@ -1,7 +1,17 @@
 mock_provider "cloudfoundry" {
+  mock_data "cloudfoundry_org" {
+    defaults = {
+      id = "591a8a56-3093-43e7-a21e-1b1b4dbd1c3a"
+    }
+  }
   mock_data "cloudfoundry_domain" {
     defaults = {
       id = "ad9f5303-b5b0-40cb-b21a-a7276efae4b1"
+    }
+  }
+  mock_data "cloudfoundry_space" {
+    defaults = {
+      id = "31a2c21d-ba50-437b-9d40-8c2d741af9e7"
     }
   }
 }

--- a/application/variables.tf
+++ b/application/variables.tf
@@ -5,7 +5,14 @@ variable "cf_org_name" {
 
 variable "cf_space_name" {
   type        = string
-  description = "cloud.gov space name"
+  description = "cloud.gov space name (deprecated; use `space` instead.)"
+  default     = ""
+}
+
+variable "space" {
+  type        = object({ id = string, name = string })
+  description = "A cloudfoundry_space resource (or any object with .id and .name). When provided, cf_space_name is not used."
+  default     = null
 }
 
 variable "environment_variables" {

--- a/clamav/main.tf
+++ b/clamav/main.tf
@@ -5,14 +5,35 @@ check "deprecated_cf_space_name" {
   }
 }
 
+data "cloudfoundry_org" "org" {
+  count = var.space == null ? 1 : 0
+  name  = var.cf_org_name
+}
+
+data "cloudfoundry_space" "space" {
+  count = var.space == null ? 1 : 0
+  name  = var.cf_space_name
+  org   = data.cloudfoundry_org.org[0].id
+}
+
 locals {
-  space_name = var.space != null ? var.space.name : var.cf_space_name
+  space = var.space != null ? var.space : {
+    id   = data.cloudfoundry_space.space[0].id
+    name = var.cf_space_name
+  }
 }
 
 resource "cloudfoundry_app" "clamav_api" {
   name       = var.name
-  space_name = local.space_name
+  space_name = local.space.name
   org_name   = var.cf_org_name
+
+  lifecycle {
+    precondition {
+      condition     = var.space != null || var.cf_space_name != ""
+      error_message = "You must provide either the `space` variable or the deprecated `cf_space_name` variable."
+    }
+  }
 
   memory                          = var.clamav_memory
   disk_quota                      = "2048M"
@@ -36,7 +57,7 @@ resource "cloudfoundry_app" "clamav_api" {
 module "route" {
   source = "../app_route"
 
-  space    = var.space
+  space    = local.space
   domain   = "apps.internal"
   hostname = var.name
   app_ids  = [cloudfoundry_app.clamav_api.id]

--- a/clamav/main.tf
+++ b/clamav/main.tf
@@ -1,6 +1,17 @@
+check "deprecated_cf_space_name" {
+  assert {
+    condition     = var.cf_space_name == ""
+    error_message = "The cf_space_name variable is deprecated. Use the `space` variable instead to pass a cloudfoundry_space resource directly."
+  }
+}
+
+locals {
+  space_name = var.space != null ? var.space.name : var.cf_space_name
+}
+
 resource "cloudfoundry_app" "clamav_api" {
   name       = var.name
-  space_name = var.cf_space_name
+  space_name = local.space_name
   org_name   = var.cf_org_name
 
   memory                          = var.clamav_memory
@@ -25,9 +36,8 @@ resource "cloudfoundry_app" "clamav_api" {
 module "route" {
   source = "../app_route"
 
-  cf_org_name   = var.cf_org_name
-  cf_space_name = var.cf_space_name
-  domain        = "apps.internal"
-  hostname      = var.name
-  app_ids       = [cloudfoundry_app.clamav_api.id]
+  space    = var.space
+  domain   = "apps.internal"
+  hostname = var.name
+  app_ids  = [cloudfoundry_app.clamav_api.id]
 }

--- a/clamav/tests/creation.tftest.hcl
+++ b/clamav/tests/creation.tftest.hcl
@@ -1,27 +1,33 @@
 mock_provider "cloudfoundry" {
-  mock_data "cloudfoundry_org" {
-    defaults = {
-      id = "591a8a56-3093-43e7-a21e-1b1b4dbd1c3a"
-    }
-  }
   mock_data "cloudfoundry_domain" {
     defaults = {
       id = "ad9f5303-b5b0-40cb-b21a-a7276efae4b1"
     }
   }
-  mock_data "cloudfoundry_space" {
-    defaults = {
-      id = "31a2c21d-ba50-437b-9d40-8c2d741af9e7"
-    }
-  }
 }
 
 variables {
-  cf_org_name   = "cloud-gov-devtools-development"
-  cf_space_name = "terraform-cloudgov-tf-tests"
+  cf_org_name = "cloud-gov-devtools-development"
+  space = {
+    id   = "31a2c21d-ba50-437b-9d40-8c2d741af9e7"
+    name = "terraform-cloudgov-tf-tests"
+  }
   name          = "terraform-cloudgov-clamav-test"
   clamav_image  = "ghcr.io/gsa-tts/clamav-rest/clamav:TAG"
   max_file_size = "30M"
+}
+
+run "test_app_creation_deprecated" {
+  command = plan
+
+  variables {
+    cf_space_name = "terraform-cloudgov-tf-tests"
+    space         = null
+  }
+
+  expect_failures = [
+    check.deprecated_cf_space_name
+  ]
 }
 
 run "test_app_creation" {

--- a/clamav/tests/creation.tftest.hcl
+++ b/clamav/tests/creation.tftest.hcl
@@ -1,7 +1,17 @@
 mock_provider "cloudfoundry" {
+  mock_data "cloudfoundry_org" {
+    defaults = {
+      id = "591a8a56-3093-43e7-a21e-1b1b4dbd1c3a"
+    }
+  }
   mock_data "cloudfoundry_domain" {
     defaults = {
       id = "ad9f5303-b5b0-40cb-b21a-a7276efae4b1"
+    }
+  }
+  mock_data "cloudfoundry_space" {
+    defaults = {
+      id = "31a2c21d-ba50-437b-9d40-8c2d741af9e7"
     }
   }
 }

--- a/clamav/variables.tf
+++ b/clamav/variables.tf
@@ -5,7 +5,14 @@ variable "cf_org_name" {
 
 variable "cf_space_name" {
   type        = string
-  description = "cloud.gov space name"
+  description = "cloud.gov space name (deprecated; use `space` instead.)"
+  default     = ""
+}
+
+variable "space" {
+  type        = object({ id = string, name = string })
+  description = "A cloudfoundry_space resource (or any object with .id and .name). When provided, cf_space_name is not used."
+  default     = null
 }
 
 variable "name" {

--- a/database/main.tf
+++ b/database/main.tf
@@ -1,5 +1,13 @@
+check "deprecated_cf_space_id" {
+  assert {
+    condition     = var.cf_space_id == ""
+    error_message = "The cf_space_id variable is deprecated. Use the `space` variable instead to pass a cloudfoundry_space resource directly."
+  }
+}
+
 locals {
-  tags = setunion(["terraform-cloudgov-managed"], var.tags)
+  space_id = var.space != null ? var.space.id : var.cf_space_id
+  tags     = setunion(["terraform-cloudgov-managed"], var.tags)
 }
 
 data "cloudfoundry_service_plans" "rds" {
@@ -10,7 +18,7 @@ data "cloudfoundry_service_plans" "rds" {
 resource "cloudfoundry_service_instance" "rds" {
   count        = var.prevent_destroy ? 0 : 1
   name         = var.name
-  space        = var.cf_space_id
+  space        = local.space_id
   type         = "managed"
   service_plan = data.cloudfoundry_service_plans.rds.service_plans.0.id
   tags         = local.tags
@@ -20,7 +28,7 @@ resource "cloudfoundry_service_instance" "rds" {
 resource "cloudfoundry_service_instance" "rds_protected" {
   count        = var.prevent_destroy ? 1 : 0
   name         = var.name
-  space        = var.cf_space_id
+  space        = local.space_id
   type         = "managed"
   service_plan = data.cloudfoundry_service_plans.rds.service_plans.0.id
   tags         = local.tags

--- a/database/tests/creation.tftest.hcl
+++ b/database/tests/creation.tftest.hcl
@@ -12,12 +12,18 @@ variables {
 }
 
 run "test_db_creation" {
+  command = plan
+
   override_resource {
     target = cloudfoundry_service_instance.rds[0]
     values = {
       id = "f6925fad-f9e8-4c93-b69f-132438f6a2f4"
     }
   }
+
+  expect_failures = [
+    check.deprecated_cf_space_id
+  ]
 
   assert {
     condition     = cloudfoundry_service_instance.rds[0].id == output.instance_id
@@ -46,6 +52,8 @@ run "test_db_creation" {
 }
 
 run "test_protected_db_creation" {
+  command = plan
+
   variables {
     prevent_destroy = true
   }
@@ -56,6 +64,10 @@ run "test_protected_db_creation" {
       id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
     }
   }
+
+  expect_failures = [
+    check.deprecated_cf_space_id
+  ]
 
   assert {
     condition     = cloudfoundry_service_instance.rds_protected[0].id == output.instance_id
@@ -87,8 +99,7 @@ run "test_db_creation_with_space_object" {
   variables {
     cf_space_id = ""
     space = {
-      id   = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
-      name = "terraform-cloudgov-tf-tests"
+      id = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
     }
   }
 

--- a/database/tests/creation.tftest.hcl
+++ b/database/tests/creation.tftest.hcl
@@ -2,7 +2,9 @@ provider "cloudfoundry" {}
 
 variables {
   # this is the ID of the terraform-cloudgov-tf-tests space
-  cf_space_id   = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
+  space = {
+    id = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
+  }
   rds_plan_name = "micro-psql"
   name          = "terraform-cloudgov-rds-test"
   tags          = ["terraform-cloudgov-managed", "tests"]
@@ -11,8 +13,13 @@ variables {
   })
 }
 
-run "test_db_creation" {
+run "test_db_creation_deprecated" {
   command = plan
+
+  variables {
+    cf_space_id = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
+    space       = null
+  }
 
   override_resource {
     target = cloudfoundry_service_instance.rds[0]
@@ -51,10 +58,12 @@ run "test_db_creation" {
   }
 }
 
-run "test_protected_db_creation" {
+run "test_protected_db_creation_deprecated" {
   command = plan
 
   variables {
+    cf_space_id     = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
+    space           = null
     prevent_destroy = true
   }
 
@@ -95,12 +104,9 @@ run "test_protected_db_creation" {
   }
 }
 
-run "test_db_creation_with_space_object" {
+run "test_db_creation" {
   variables {
     cf_space_id = ""
-    space = {
-      id = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
-    }
   }
 
   override_resource {

--- a/database/tests/creation.tftest.hcl
+++ b/database/tests/creation.tftest.hcl
@@ -82,3 +82,30 @@ run "test_protected_db_creation" {
     error_message = "Service instance json_params should be configurable"
   }
 }
+
+run "test_db_creation_with_space_object" {
+  variables {
+    cf_space_id = ""
+    space = {
+      id   = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
+      name = "terraform-cloudgov-tf-tests"
+    }
+  }
+
+  override_resource {
+    target = cloudfoundry_service_instance.rds[0]
+    values = {
+      id = "f6925fad-f9e8-4c93-b69f-132438f6a2f4"
+    }
+  }
+
+  assert {
+    condition     = cloudfoundry_service_instance.rds[0].id == output.instance_id
+    error_message = "Instance ID output must match the service instance"
+  }
+
+  assert {
+    condition     = cloudfoundry_service_instance.rds[0].name == var.name
+    error_message = "Service instance name should match the name variable"
+  }
+}

--- a/database/tests/creation.tftest.hcl
+++ b/database/tests/creation.tftest.hcl
@@ -31,6 +31,40 @@ run "test_db_creation_deprecated" {
   expect_failures = [
     check.deprecated_cf_space_id
   ]
+}
+
+run "test_protected_db_creation_deprecated" {
+  command = plan
+
+  variables {
+    cf_space_id     = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
+    space           = null
+    prevent_destroy = true
+  }
+
+  override_resource {
+    target = cloudfoundry_service_instance.rds_protected[0]
+    values = {
+      id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    }
+  }
+
+  expect_failures = [
+    check.deprecated_cf_space_id
+  ]
+}
+
+run "test_db_creation" {
+  variables {
+    cf_space_id = ""
+  }
+
+  override_resource {
+    target = cloudfoundry_service_instance.rds[0]
+    values = {
+      id = "f6925fad-f9e8-4c93-b69f-132438f6a2f4"
+    }
+  }
 
   assert {
     condition     = cloudfoundry_service_instance.rds[0].id == output.instance_id
@@ -58,12 +92,9 @@ run "test_db_creation_deprecated" {
   }
 }
 
-run "test_protected_db_creation_deprecated" {
-  command = plan
-
+run "test_protected_db_creation" {
   variables {
-    cf_space_id     = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
-    space           = null
+    cf_space_id     = ""
     prevent_destroy = true
   }
 
@@ -73,10 +104,6 @@ run "test_protected_db_creation_deprecated" {
       id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
     }
   }
-
-  expect_failures = [
-    check.deprecated_cf_space_id
-  ]
 
   assert {
     condition     = cloudfoundry_service_instance.rds_protected[0].id == output.instance_id
@@ -101,28 +128,5 @@ run "test_protected_db_creation_deprecated" {
   assert {
     condition     = cloudfoundry_service_instance.rds_protected[0].parameters == "{\"backup_retention_period\":30}"
     error_message = "Service instance json_params should be configurable"
-  }
-}
-
-run "test_db_creation" {
-  variables {
-    cf_space_id = ""
-  }
-
-  override_resource {
-    target = cloudfoundry_service_instance.rds[0]
-    values = {
-      id = "f6925fad-f9e8-4c93-b69f-132438f6a2f4"
-    }
-  }
-
-  assert {
-    condition     = cloudfoundry_service_instance.rds[0].id == output.instance_id
-    error_message = "Instance ID output must match the service instance"
-  }
-
-  assert {
-    condition     = cloudfoundry_service_instance.rds[0].name == var.name
-    error_message = "Service instance name should match the name variable"
   }
 }

--- a/database/variables.tf
+++ b/database/variables.tf
@@ -1,6 +1,15 @@
 variable "cf_space_id" {
   type        = string
-  description = "cloud.gov space GUID"
+  description = "cloud.gov space GUID (deprecated; use `space` instead)"
+  default     = ""
+}
+
+variable "space" {
+  type = object({
+    id = string
+  })
+  description = "A cloudfoundry_space resource (or any object with .id). When provided, cf_space_id is not used."
+  default     = null
 }
 
 variable "name" {

--- a/drupal/main.tf
+++ b/drupal/main.tf
@@ -8,7 +8,7 @@ locals {
 module "database" {
   source = "../database"
 
-  cf_space_id   = var.cf_space.id
+  space         = var.cf_space
   name          = local.rds_name
   rds_plan_name = var.rds_plan_name
   tags          = setunion(local.tags, ["drupal-db"])
@@ -17,7 +17,7 @@ module "database" {
 module "bucket" {
   source = "../s3"
 
-  cf_space_id  = var.cf_space.id
+  space        = var.cf_space
   name         = local.s3_name
   s3_plan_name = var.s3_plan_name
   tags         = setunion(local.tags, ["drupal-bucket"])

--- a/logshipper/main.tf
+++ b/logshipper/main.tf
@@ -107,9 +107,8 @@ resource "random_pet" "random_route" {
 module "route" {
   source = "../app_route"
 
-  cf_org_name   = var.cf_org_name
-  cf_space_name = var.cf_space.name
-  domain        = var.domain
-  hostname      = coalesce(var.hostname, random_pet.random_route.id)
-  app_ids       = [cloudfoundry_app.logshipper.id]
+  space    = var.cf_space
+  domain   = var.domain
+  hostname = coalesce(var.hostname, random_pet.random_route.id)
+  app_ids  = [cloudfoundry_app.logshipper.id]
 }

--- a/redis/main.tf
+++ b/redis/main.tf
@@ -1,5 +1,13 @@
+check "deprecated_cf_space_id" {
+  assert {
+    condition     = var.cf_space_id == ""
+    error_message = "The cf_space_id variable is deprecated. Use the `space` variable instead to pass a cloudfoundry_space resource directly."
+  }
+}
+
 locals {
-  tags = setunion(["terraform-cloudgov-managed"], var.tags)
+  space_id = var.space != null ? var.space.id : var.cf_space_id
+  tags     = setunion(["terraform-cloudgov-managed"], var.tags)
 }
 
 data "cloudfoundry_service_plans" "redis" {
@@ -9,7 +17,7 @@ data "cloudfoundry_service_plans" "redis" {
 
 resource "cloudfoundry_service_instance" "redis" {
   name         = var.name
-  space        = var.cf_space_id
+  space        = local.space_id
   type         = "managed"
   service_plan = data.cloudfoundry_service_plans.redis.service_plans.0.id
   tags         = local.tags

--- a/redis/tests/creation.tftest.hcl
+++ b/redis/tests/creation.tftest.hcl
@@ -31,6 +31,19 @@ run "test_redis_creation_deprecated" {
   expect_failures = [
     check.deprecated_cf_space_id
   ]
+}
+
+run "test_redis_creation" {
+  variables {
+    cf_space_id = ""
+  }
+
+  override_resource {
+    target = cloudfoundry_service_instance.redis
+    values = {
+      id = "2a4dae63-2fb7-4a76-975d-eebb9a7b8d96"
+    }
+  }
 
   assert {
     condition     = cloudfoundry_service_instance.redis.id == output.instance_id
@@ -55,28 +68,5 @@ run "test_redis_creation_deprecated" {
   assert {
     condition     = cloudfoundry_service_instance.redis.parameters == "{\"engineVersion\":\"7.0\"}"
     error_message = "Service instance parameters should be configurable"
-  }
-}
-
-run "test_redis_creation" {
-  variables {
-    cf_space_id = ""
-  }
-
-  override_resource {
-    target = cloudfoundry_service_instance.redis
-    values = {
-      id = "2a4dae63-2fb7-4a76-975d-eebb9a7b8d96"
-    }
-  }
-
-  assert {
-    condition     = cloudfoundry_service_instance.redis.id == output.instance_id
-    error_message = "Instance ID output must match the service instance"
-  }
-
-  assert {
-    condition     = cloudfoundry_service_instance.redis.name == var.name
-    error_message = "Service instance name should match the name variable"
   }
 }

--- a/redis/tests/creation.tftest.hcl
+++ b/redis/tests/creation.tftest.hcl
@@ -12,12 +12,18 @@ variables {
 }
 
 run "test_redis_creation" {
+  command = plan
+
   override_resource {
     target = cloudfoundry_service_instance.redis
     values = {
       id = "2a4dae63-2fb7-4a76-975d-eebb9a7b8d96"
     }
   }
+
+  expect_failures = [
+    check.deprecated_cf_space_id
+  ]
 
   assert {
     condition     = cloudfoundry_service_instance.redis.id == output.instance_id
@@ -49,8 +55,7 @@ run "test_redis_creation_with_space_object" {
   variables {
     cf_space_id = ""
     space = {
-      id   = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
-      name = "terraform-cloudgov-tf-tests"
+      id = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
     }
   }
 

--- a/redis/tests/creation.tftest.hcl
+++ b/redis/tests/creation.tftest.hcl
@@ -2,7 +2,9 @@ provider "cloudfoundry" {}
 
 variables {
   # this is the ID of the terraform-cloudgov-tf-tests space
-  cf_space_id     = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
+  space = {
+    id = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
+  }
   redis_plan_name = "redis-dev"
   name            = "terraform-cloudgov-redis-test"
   tags            = ["terraform-cloudgov-managed", "tests"]
@@ -11,8 +13,13 @@ variables {
   })
 }
 
-run "test_redis_creation" {
+run "test_redis_creation_deprecated" {
   command = plan
+
+  variables {
+    cf_space_id = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
+    space       = null
+  }
 
   override_resource {
     target = cloudfoundry_service_instance.redis
@@ -51,12 +58,9 @@ run "test_redis_creation" {
   }
 }
 
-run "test_redis_creation_with_space_object" {
+run "test_redis_creation" {
   variables {
     cf_space_id = ""
-    space = {
-      id = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
-    }
   }
 
   override_resource {

--- a/redis/tests/creation.tftest.hcl
+++ b/redis/tests/creation.tftest.hcl
@@ -44,3 +44,30 @@ run "test_redis_creation" {
     error_message = "Service instance parameters should be configurable"
   }
 }
+
+run "test_redis_creation_with_space_object" {
+  variables {
+    cf_space_id = ""
+    space = {
+      id   = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
+      name = "terraform-cloudgov-tf-tests"
+    }
+  }
+
+  override_resource {
+    target = cloudfoundry_service_instance.redis
+    values = {
+      id = "2a4dae63-2fb7-4a76-975d-eebb9a7b8d96"
+    }
+  }
+
+  assert {
+    condition     = cloudfoundry_service_instance.redis.id == output.instance_id
+    error_message = "Instance ID output must match the service instance"
+  }
+
+  assert {
+    condition     = cloudfoundry_service_instance.redis.name == var.name
+    error_message = "Service instance name should match the name variable"
+  }
+}

--- a/redis/variables.tf
+++ b/redis/variables.tf
@@ -1,6 +1,15 @@
 variable "cf_space_id" {
   type        = string
-  description = "cloud.gov space id"
+  description = "cloud.gov space id (deprecated; use `space` instead)"
+  default     = ""
+}
+
+variable "space" {
+  type = object({
+    id = string
+  })
+  description = "A cloudfoundry_space resource (or any object with .id). When provided, cf_space_id is not used."
+  default     = null
 }
 
 variable "name" {

--- a/s3/main.tf
+++ b/s3/main.tf
@@ -1,5 +1,13 @@
+check "deprecated_cf_space_id" {
+  assert {
+    condition     = var.cf_space_id == ""
+    error_message = "The cf_space_id variable is deprecated. Use the `space` variable instead to pass a cloudfoundry_space resource directly."
+  }
+}
+
 locals {
-  tags = setunion(["terraform-cloudgov-managed"], var.tags)
+  space_id = var.space != null ? var.space.id : var.cf_space_id
+  tags     = setunion(["terraform-cloudgov-managed"], var.tags)
 }
 
 data "cloudfoundry_service_plans" "s3" {
@@ -9,7 +17,7 @@ data "cloudfoundry_service_plans" "s3" {
 
 resource "cloudfoundry_service_instance" "bucket" {
   name         = var.name
-  space        = var.cf_space_id
+  space        = local.space_id
   type         = "managed"
   service_plan = data.cloudfoundry_service_plans.s3.service_plans.0.id
   tags         = local.tags

--- a/s3/tests/creation.tftest.hcl
+++ b/s3/tests/creation.tftest.hcl
@@ -21,6 +21,28 @@ run "test_bucket_creation_deprecated" {
   expect_failures = [
     check.deprecated_cf_space_id
   ]
+}
+
+run "test_parameters_deprecated" {
+  command = plan
+
+  variables {
+    cf_space_id = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
+    space       = null
+    json_params = jsonencode({
+      object_ownership = "BucketOwnerEnforced"
+    })
+  }
+
+  expect_failures = [
+    check.deprecated_cf_space_id
+  ]
+}
+
+run "test_bucket_creation" {
+  variables {
+    cf_space_id = ""
+  }
 
   assert {
     condition     = can(regex("^\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}$", output.bucket_id))
@@ -48,39 +70,17 @@ run "test_bucket_creation_deprecated" {
   }
 }
 
-run "test_parameters_deprecated" {
+run "test_parameters" {
   command = plan
 
   variables {
-    cf_space_id = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
-    space       = null
     json_params = jsonencode({
       object_ownership = "BucketOwnerEnforced"
     })
   }
 
-  expect_failures = [
-    check.deprecated_cf_space_id
-  ]
-
   assert {
     condition     = cloudfoundry_service_instance.bucket.parameters == "{\"object_ownership\":\"BucketOwnerEnforced\"}"
     error_message = "Service instance parameters should be configurable"
-  }
-}
-
-run "test_bucket_creation" {
-  variables {
-    cf_space_id = ""
-  }
-
-  assert {
-    condition     = cloudfoundry_service_instance.bucket.id == output.bucket_id
-    error_message = "Bucket ID output must match the service instance"
-  }
-
-  assert {
-    condition     = cloudfoundry_service_instance.bucket.name == var.name
-    error_message = "Service instance name should match the name variable"
   }
 }

--- a/s3/tests/creation.tftest.hcl
+++ b/s3/tests/creation.tftest.hcl
@@ -49,3 +49,23 @@ run "test_parameters" {
     error_message = "Service instance parameters should be configurable"
   }
 }
+
+run "test_bucket_creation_with_space_object" {
+  variables {
+    cf_space_id = ""
+    space = {
+      id   = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
+      name = "terraform-cloudgov-tf-tests"
+    }
+  }
+
+  assert {
+    condition     = cloudfoundry_service_instance.bucket.id == output.bucket_id
+    error_message = "Bucket ID output must match the service instance"
+  }
+
+  assert {
+    condition     = cloudfoundry_service_instance.bucket.name == var.name
+    error_message = "Service instance name should match the name variable"
+  }
+}

--- a/s3/tests/creation.tftest.hcl
+++ b/s3/tests/creation.tftest.hcl
@@ -2,14 +2,21 @@ provider "cloudfoundry" {}
 
 variables {
   # this is the ID of the terraform-cloudgov-tf-tests space
-  cf_space_id  = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
+  space = {
+    id = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
+  }
   s3_plan_name = "basic-sandbox"
   name         = "terraform-cloudgov-s3-test"
   tags         = ["terraform-cloudgov-managed", "tests"]
 }
 
-run "test_bucket_creation" {
+run "test_bucket_creation_deprecated" {
   command = plan
+
+  variables {
+    cf_space_id = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
+    space       = null
+  }
 
   expect_failures = [
     check.deprecated_cf_space_id
@@ -41,10 +48,12 @@ run "test_bucket_creation" {
   }
 }
 
-run "test_parameters" {
+run "test_parameters_deprecated" {
   command = plan
 
   variables {
+    cf_space_id = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
+    space       = null
     json_params = jsonencode({
       object_ownership = "BucketOwnerEnforced"
     })
@@ -60,12 +69,9 @@ run "test_parameters" {
   }
 }
 
-run "test_bucket_creation_with_space_object" {
+run "test_bucket_creation" {
   variables {
     cf_space_id = ""
-    space = {
-      id = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
-    }
   }
 
   assert {

--- a/s3/tests/creation.tftest.hcl
+++ b/s3/tests/creation.tftest.hcl
@@ -9,6 +9,12 @@ variables {
 }
 
 run "test_bucket_creation" {
+  command = plan
+
+  expect_failures = [
+    check.deprecated_cf_space_id
+  ]
+
   assert {
     condition     = can(regex("^\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}$", output.bucket_id))
     error_message = "Bucket ID should be a GUID"
@@ -44,6 +50,10 @@ run "test_parameters" {
     })
   }
 
+  expect_failures = [
+    check.deprecated_cf_space_id
+  ]
+
   assert {
     condition     = cloudfoundry_service_instance.bucket.parameters == "{\"object_ownership\":\"BucketOwnerEnforced\"}"
     error_message = "Service instance parameters should be configurable"
@@ -54,8 +64,7 @@ run "test_bucket_creation_with_space_object" {
   variables {
     cf_space_id = ""
     space = {
-      id   = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
-      name = "terraform-cloudgov-tf-tests"
+      id = "f23cbf69-66a1-4b1d-83d4-e497abdb8dcb"
     }
   }
 

--- a/s3/variables.tf
+++ b/s3/variables.tf
@@ -1,6 +1,15 @@
 variable "cf_space_id" {
   type        = string
-  description = "cloud.gov space id"
+  description = "cloud.gov space id (deprecated; use `space` instead)"
+  default     = ""
+}
+
+variable "space" {
+  type = object({
+    id = string
+  })
+  description = "A cloudfoundry_space resource (or any object with .id). When provided, cf_space_id is not used."
+  default     = null
 }
 
 variable "name" {

--- a/spiffworkflow/backend.tf
+++ b/spiffworkflow/backend.tf
@@ -154,7 +154,7 @@ resource "archive_file" "code" {
 resource "cloudfoundry_app" "backend" {
   name       = "${local.prefix}-backend"
   org_name   = var.cf_org_name
-  space_name = var.cf_space_name
+  space_name = var.space.name
 
   # Conditional properties based on deployment method
   buildpacks = var.backend_deployment_method == "buildpack" ? ["python_buildpack"] : null

--- a/spiffworkflow/main.tf
+++ b/spiffworkflow/main.tf
@@ -44,7 +44,7 @@ data "docker_registry_image" "connector" {
 resource "cloudfoundry_app" "connector" {
   name                       = "${local.prefix}-connector"
   org_name                   = var.cf_org_name
-  space_name                 = var.cf_space_name
+  space_name                 = var.space.name
   docker_image               = "${local.connector_baseimage}@${data.docker_registry_image.connector.sha256_digest}"
   memory                     = var.connector_memory
   instances                  = var.connector_instances
@@ -74,7 +74,7 @@ data "docker_registry_image" "frontend" {
 resource "cloudfoundry_app" "frontend" {
   name              = "${local.prefix}-frontend"
   org_name          = var.cf_org_name
-  space_name        = var.cf_space_name
+  space_name        = var.space.name
   docker_image      = "${local.frontend_baseimage}@${data.docker_registry_image.frontend.sha256_digest}"
   memory            = var.frontend_memory
   instances         = var.frontend_instances

--- a/spiffworkflow/routing.tf
+++ b/spiffworkflow/routing.tf
@@ -16,8 +16,8 @@
 module "connector_route" {
   source = "../app_route"
 
+  space         = var.space
   cf_org_name   = var.cf_org_name
-  cf_space_name = var.cf_space_name
   domain        = "apps.internal"
   hostname      = "${local.prefix}-connector"
   app_ids       = [cloudfoundry_app.connector.id]
@@ -26,8 +26,8 @@ module "connector_route" {
 module "frontend_route" {
   source = "../app_route"
 
+  space         = var.space
   cf_org_name   = var.cf_org_name
-  cf_space_name = var.cf_space_name
   hostname      = local.prefix
   app_ids       = [cloudfoundry_app.frontend.id]
 }
@@ -35,8 +35,8 @@ module "frontend_route" {
 module "backend_route" {
   source = "../app_route"
 
+  space         = var.space
   cf_org_name   = var.cf_org_name
-  cf_space_name = var.cf_space_name
   hostname      = local.prefix
   path          = "/api"
 }

--- a/spiffworkflow/routing.tf
+++ b/spiffworkflow/routing.tf
@@ -16,29 +16,29 @@
 module "connector_route" {
   source = "../app_route"
 
-  space         = var.space
-  cf_org_name   = var.cf_org_name
-  domain        = "apps.internal"
-  hostname      = "${local.prefix}-connector"
-  app_ids       = [cloudfoundry_app.connector.id]
+  space       = var.space
+  cf_org_name = var.cf_org_name
+  domain      = "apps.internal"
+  hostname    = "${local.prefix}-connector"
+  app_ids     = [cloudfoundry_app.connector.id]
 }
 
 module "frontend_route" {
   source = "../app_route"
 
-  space         = var.space
-  cf_org_name   = var.cf_org_name
-  hostname      = local.prefix
-  app_ids       = [cloudfoundry_app.frontend.id]
+  space       = var.space
+  cf_org_name = var.cf_org_name
+  hostname    = local.prefix
+  app_ids     = [cloudfoundry_app.frontend.id]
 }
 
 module "backend_route" {
   source = "../app_route"
 
-  space         = var.space
-  cf_org_name   = var.cf_org_name
-  hostname      = local.prefix
-  path          = "/api"
+  space       = var.space
+  cf_org_name = var.cf_org_name
+  hostname    = local.prefix
+  path        = "/api"
 }
 
 # -----------------------------------------------------------------------------

--- a/spiffworkflow/routing.tf
+++ b/spiffworkflow/routing.tf
@@ -16,29 +16,26 @@
 module "connector_route" {
   source = "../app_route"
 
-  space       = var.space
-  cf_org_name = var.cf_org_name
-  domain      = "apps.internal"
-  hostname    = "${local.prefix}-connector"
-  app_ids     = [cloudfoundry_app.connector.id]
+  space    = var.space
+  domain   = "apps.internal"
+  hostname = "${local.prefix}-connector"
+  app_ids  = [cloudfoundry_app.connector.id]
 }
 
 module "frontend_route" {
   source = "../app_route"
 
-  space       = var.space
-  cf_org_name = var.cf_org_name
-  hostname    = local.prefix
-  app_ids     = [cloudfoundry_app.frontend.id]
+  space    = var.space
+  hostname = local.prefix
+  app_ids  = [cloudfoundry_app.frontend.id]
 }
 
 module "backend_route" {
   source = "../app_route"
 
-  space       = var.space
-  cf_org_name = var.cf_org_name
-  hostname    = local.prefix
-  path        = "/api"
+  space    = var.space
+  hostname = local.prefix
+  path     = "/api"
 }
 
 # -----------------------------------------------------------------------------

--- a/spiffworkflow/tests/creation.tftest.hcl
+++ b/spiffworkflow/tests/creation.tftest.hcl
@@ -34,7 +34,7 @@ mock_provider "docker" {
 }
 
 variables {
-  cf_org_name                       = "cloud-gov-devtools-development"
+  cf_org_name = "cloud-gov-devtools-development"
   space = {
     id   = "31a2c21d-ba50-437b-9d40-8c2d741af9e7"
     name = "terraform-cloudgov-tf-tests"

--- a/spiffworkflow/tests/creation.tftest.hcl
+++ b/spiffworkflow/tests/creation.tftest.hcl
@@ -35,7 +35,10 @@ mock_provider "docker" {
 
 variables {
   cf_org_name                       = "cloud-gov-devtools-development"
-  cf_space_name                     = "terraform-cloudgov-tf-tests"
+  space = {
+    id   = "31a2c21d-ba50-437b-9d40-8c2d741af9e7"
+    name = "terraform-cloudgov-tf-tests"
+  }
   process_models_ssh_key            = ""
   backend_database_service_instance = "spiffworkflow-db"
   name                              = "spiffworkflow-backend"
@@ -83,5 +86,20 @@ run "test_spiff_instances" {
   assert {
     condition     = cloudfoundry_app.backend.health_check_http_endpoint == var.health_check_endpoint
     error_message = "Health check endpoint must match backend health check endpoint"
+  }
+}
+
+run "test_spiff_instances_with_space_object" {
+  assert {
+    condition     = cloudfoundry_app.connector.name == "${var.name}-connector"
+    error_message = "Connector App name should be ${var.name}-connector"
+  }
+  assert {
+    condition     = cloudfoundry_app.backend.name == "${var.name}-backend"
+    error_message = "Backend App name should be ${var.name}-backend"
+  }
+  assert {
+    condition     = cloudfoundry_app.frontend.name == "${var.name}-frontend"
+    error_message = "Frontend App name should be ${var.name}-frontend"
   }
 }

--- a/spiffworkflow/variables.tf
+++ b/spiffworkflow/variables.tf
@@ -3,9 +3,12 @@ variable "cf_org_name" {
   description = "cloud.gov organization name"
 }
 
-variable "cf_space_name" {
-  type        = string
-  description = "cloud.gov space in which to deploy the apps"
+variable "space" {
+  type = object({
+    id   = string
+    name = string
+  })
+  description = "A cloudfoundry_space resource (or any object with .id and .name)."
 }
 
 variable "name" {


### PR DESCRIPTION
## 🛠 Summary of changes

Reduces the need to explicitly pass .id and .name attributes to modules. Just pass modules a resource, and let duck-typing extract the resource attribute values the module needs! This change eliminates redundant data resource lookups (aka cloud.gov API calls), which makes plans and applies faster. (For the permitting project, there were a ton of these implied via the spiffworkflow module; this likely shaves off 10 seconds or so.) Plus it makes reading and reasoning about code easier by keeping resource dependencies explicit rather than sending needed attributes on a side-trip through string vars.

* Adds a new variable "space" to various modules so that you can just pass a `cloudfoundry_space` resource (or data resource!) directly
  * This makes use of Terraform's support for duck-typing
  * This is backward compatible with the community Terraform provider resources, for anyone still using them (I think FAC does in a few places)
* Adds tests for the new methods for specifying the space
* Marks the old parameters as deprecated in plan output to lay ground for removing them in the future
  * I'm intentionally breaking backward compatibility on the spiffworkflow module because there're no users other than the permitting project, and we can pull this same change from `main` into the branch we're using and update the client at the same time, post-merge.

## 📜 Testing Plan

How would a peer test this work?

- Run the tests

cc @Mwindo FYI