### PR TITLE
Add PROXYROUTE to Spiff frontend

### DIFF
--- a/spiffworkflow/howto-manual-deployment/manifest.yml
+++ b/spiffworkflow/howto-manual-deployment/manifest.yml
@@ -101,6 +101,13 @@ applications:
       image: ((frontend-image))
     memory: 256M
     health-check-type: port
+    command: |
+      # Make sure the Cloud Foundry-provided CA is recognized when making TLS connections
+      cat /etc/cf-system-certificates/* > /usr/local/share/ca-certificates/cf-system-certificates.crt
+      /usr/sbin/update-ca-certificates
+      export HTTPS_PROXY='((https-proxy))'
+      export NO_PROXY='apps.internal'
+      /app/bin/boot_server_in_docker
     env:
       APPLICATION_ROOT: "/"
       PORT0: "80"

--- a/spiffworkflow/main.tf
+++ b/spiffworkflow/main.tf
@@ -47,6 +47,7 @@ resource "cloudfoundry_app" "frontend" {
   health_check_type = "port"
 
   environment = {
+    PROXYROUTE : var.https_proxy
     APPLICATION_ROOT : "/"
     PORT0 : "80"
     SPIFFWORKFLOW_FRONTEND_RUNTIME_CONFIG_APP_ROUTING_STRATEGY : "path_based"

--- a/spiffworkflow/main.tf
+++ b/spiffworkflow/main.tf
@@ -45,6 +45,20 @@ resource "cloudfoundry_app" "frontend" {
   instances         = var.frontend_instances
   strategy          = "rolling"
   health_check_type = "port"
+  command                    = <<-COMMAND
+  # Make sure the Cloud Foundry-provided CA is recognized when making TLS connections
+  cat /etc/cf-system-certificates/* > /usr/local/share/ca-certificates/cf-system-certificates.crt
+  /usr/sbin/update-ca-certificates
+
+  # Set the HTTPS_PROXY
+  if [ -n "$PROXYROUTE" ]; then
+    echo "Setting the https proxy"
+    export HTTPS_PROXY="$PROXYROUTE"
+    export NO_PROXY="apps.internal"  # For internal traffic
+  fi
+
+  /app/bin/boot_server_in_docker
+  COMMAND
 
   environment = {
     PROXYROUTE : var.https_proxy

--- a/spiffworkflow/main.tf
+++ b/spiffworkflow/main.tf
@@ -45,7 +45,7 @@ resource "cloudfoundry_app" "frontend" {
   instances         = var.frontend_instances
   strategy          = "rolling"
   health_check_type = "port"
-  command                    = <<-COMMAND
+  command           = <<-COMMAND
   # Make sure the Cloud Foundry-provided CA is recognized when making TLS connections
   cat /etc/cf-system-certificates/* > /usr/local/share/ca-certificates/cf-system-certificates.crt
   /usr/sbin/update-ca-certificates


### PR DESCRIPTION
After this is merged, point https://github.com/GSA-TTS/pic-blm-cxworks/pull/692 to use the resulting `custom-spiffworkflow-connector-stable` commit hash and test that PR in dev.