### PR TITLE
[security] fix(ci): add least-privilege permissions to all workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,11 @@ on:
     branches-ignore:
       - main
 
+# Security: restrict GITHUB_TOKEN to least privilege.
+# See: https://www.upwind.io/feed/hackerbot-claw-github-actions-pull-request-rce
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+# Security: restrict GITHUB_TOKEN to least privilege.
+# See: https://www.upwind.io/feed/hackerbot-claw-github-actions-pull-request-rce
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-trivy-cache.yml
+++ b/.github/workflows/update-trivy-cache.yml
@@ -6,6 +6,12 @@ on:
     - cron: '0 0 * * *'  # Run daily at midnight UTC
   workflow_dispatch:  # Allow manual triggering
 
+# Security: restrict GITHUB_TOKEN to least privilege.
+# See: https://www.upwind.io/feed/hackerbot-claw-github-actions-pull-request-rce
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   update-trivy-db:
     runs-on: ubuntu-latest

--- a/database/tests/creation.tftest.hcl
+++ b/database/tests/creation.tftest.hcl
@@ -98,6 +98,16 @@ run "test_protected_db_creation" {
     prevent_destroy = true
   }
 
+  # The previous run created rds[0] in state. With prevent_destroy = true,
+  # count drops to 0 and Terraform must destroy it. An override is needed
+  # so the provider can read the resource during teardown.
+  override_resource {
+    target = cloudfoundry_service_instance.rds[0]
+    values = {
+      id = "f6925fad-f9e8-4c93-b69f-132438f6a2f4"
+    }
+  }
+
   override_resource {
     target = cloudfoundry_service_instance.rds_protected[0]
     values = {


### PR DESCRIPTION
Without explicit `permissions:` blocks, workflows receive the repository's default `GITHUB_TOKEN` permissions (often write-all). An exfiltrated token could be used to push commits, modify workflows, or tamper with releases.

Add permissions to:
- `test.yml`: contents: read
- `lint.yml`: contents: read
- `update-trivy-cache.yml`: contents: read, actions: write (for cache save) (`pull-and-publish-images.yml` already had correct job-level permissions)

Ref: https://www.upwind.io/feed/hackerbot-claw-github-actions-pull-request-rce
