### PR TITLE
Update Trivy actions past compromised versions

### DIFF
--- a/.github/workflows/pull-and-publish-images.yml
+++ b/.github/workflows/pull-and-publish-images.yml
@@ -39,7 +39,7 @@ jobs:
         run: docker pull ${{ matrix.image.name }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@0.35.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db

--- a/.github/workflows/pull-and-publish-images.yml
+++ b/.github/workflows/pull-and-publish-images.yml
@@ -39,7 +39,7 @@ jobs:
         run: docker pull ${{ matrix.image.name }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db

--- a/.github/workflows/pull-and-publish-images.yml
+++ b/.github/workflows/pull-and-publish-images.yml
@@ -39,7 +39,7 @@ jobs:
         run: docker pull ${{ matrix.image.name }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,ghcr.io/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db

--- a/database/tests/creation.tftest.hcl
+++ b/database/tests/creation.tftest.hcl
@@ -98,6 +98,16 @@ run "test_protected_db_creation" {
     prevent_destroy = true
   }
 
+  # The previous run created rds[0] in state. With prevent_destroy = true,
+  # count drops to 0 and Terraform must destroy it. An override is needed
+  # so the provider can read the resource during teardown.
+  override_resource {
+    target = cloudfoundry_service_instance.rds[0]
+    values = {
+      id = "f6925fad-f9e8-4c93-b69f-132438f6a2f4"
+    }
+  }
+
   override_resource {
     target = cloudfoundry_service_instance.rds_protected[0]
     values = {


### PR DESCRIPTION
Looks like [we only tried to use Trivy once since the compromise on March 19th](https://github.com/GSA-TTS/terraform-cloudgov/actions/workflows/pull-and-publish-images.yml), and [that invocation failed because the action had already been pulled](https://github.com/GSA-TTS/terraform-cloudgov/actions/runs/23396524562/job/68060675768).