### PR TITLE
Stop tests from competing for namespace

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     name: Integration test
+    concurrency:
+      group: terraform-test-${{ matrix.module }}
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -29,6 +31,8 @@ jobs:
   test-with-zip:
     runs-on: ubuntu-latest
     name: Integration test with zip
+    concurrency:
+      group: terraform-test-${{ matrix.module }}
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/database/tests/creation.tftest.hcl
+++ b/database/tests/creation.tftest.hcl
@@ -98,6 +98,16 @@ run "test_protected_db_creation" {
     prevent_destroy = true
   }
 
+  # The previous run created rds[0] in state. With prevent_destroy = true,
+  # count drops to 0 and Terraform must destroy it. An override is needed
+  # so the provider can read the resource during teardown.
+  override_resource {
+    target = cloudfoundry_service_instance.rds[0]
+    values = {
+      id = "f6925fad-f9e8-4c93-b69f-132438f6a2f4"
+    }
+  }
+
   override_resource {
     target = cloudfoundry_service_instance.rds_protected[0]
     values = {


### PR DESCRIPTION
## 🛠 Summary of changes

When integration tests are running on two PRs concurrently, there's a race condition because integration tests use hardcoded names/resources. That means there can be collisions that cause tests to fail, [like this](https://github.com/GSA-TTS/terraform-cloudgov/actions/runs/23785255993/job/69306814382). 

There was protection against running integration tests concurrently within the same PR, but not across PRs. This PR adds that missing protection.
