### PR TITLE
Eliminate false-positive secret leaks

### DIFF
--- a/clamav/tests/creation.tftest.hcl
+++ b/clamav/tests/creation.tftest.hcl
@@ -97,7 +97,7 @@ run "test_with_proxy" {
     proxy_server   = "proxy.server"
     proxy_port     = "8900"
     proxy_username = "username"
-    proxy_password = "not-a-real-password"
+    proxy_password = "not-a-secret-password"
   }
 
   assert {

--- a/spiffworkflow/howto-manual-deployment/vars.yml-template
+++ b/spiffworkflow/howto-manual-deployment/vars.yml-template
@@ -3,10 +3,10 @@ frontend-image: ghcr.io/gsa-tts/spiffworkflow-frontend:deploy-to-cloud-gov-lates
 connector-image: ghcr.io/gsa-tts/connector-proxy-demo:deploy-to-cloud-gov-latest
 
 db-instance: spiffworkflow-db
-backend-flask-session-key: 66eef9e98a3f4e6f85258154e4a1bdce
-connector-flask-secret-key: 66eef9e99a3f4e6f85258154e4a1bdce
+backend-flask-session-key: REPLACE_ME_WITH_RANDOM_HEX_32
+connector-flask-secret-key: REPLACE_ME_WITH_RANDOM_HEX_32
 git-process-models-repo: git@github.com:GSA-TTS/gsa-process-models.git
-openid-secret: flarblegarble
+openid-secret: REPLACE_ME_WITH_OPENID_SECRET
 source-branch: process-models-playground
 target-branch-for-publish: publish-staging-branch
 


### PR DESCRIPTION
"not-a-secret" is explicitly allowed as an indicator of an intentionally-committed secret

🎫 Addresses (part of) issue: #119 

