### PR TITLE
Move to newer spiffworkflow images

### DIFF
--- a/.github/workflows/pull-and-publish-images.yml
+++ b/.github/workflows/pull-and-publish-images.yml
@@ -19,11 +19,11 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - name: ghcr.io/sartography/spiffworkflow-backend:v1.1.5
+          - name: ghcr.io/sartography/spiffworkflow-backend:v2.2.0
             short-name: spiffarena-backend
-          - name: ghcr.io/sartography/spiffworkflow-frontend:v1.1.5
+          - name: ghcr.io/sartography/spiffworkflow-frontend:v2.2.0
             short-name: spiffarena-frontend
-          - name: ghcr.io/sartography/connector-proxy-demo:v1.1.5
+          - name: ghcr.io/sartography/connector-proxy-demo:v2.2.0
             short-name: spiffarena-connector
           - name: ghcr.io/gsa-tts/clamav-rest/clamav:latest
             short-name: clamav-proxy-support


### PR DESCRIPTION
Updated Docker image versions in the workflow to v2.2.0 for spiffworkflow-backend, spiffworkflow-frontend, and connector-proxy-demo.

Had to do this because Sartography deleted their image tags for older versions. 😞 

<img width="1334" height="759" alt="image" src="https://github.com/user-attachments/assets/4b28830e-d2d7-4036-a725-468bf601fb5d" />
