### PR TITLE
fix: remove --frozen flag from uv pip compile (not supported)

### DIFF
--- a/spiffworkflow/build-for-cloudfoundry.sh
+++ b/spiffworkflow/build-for-cloudfoundry.sh
@@ -375,9 +375,9 @@ if [ -f "${BACKEND_DIR}/uv.lock" ] && [ -f "${BACKEND_DIR}/pyproject.toml" ]; th
 
   echo "Using uv to generate requirements.txt..."
   if [ -n "$COMPILE_PYTHON_VERSION" ]; then
-    (cd "${BACKEND_DIR}" && uv pip compile --quiet --no-header --frozen --python-version "$COMPILE_PYTHON_VERSION" --output-file requirements.txt pyproject.toml > /dev/null 2>&1) || fatal "uv pip compile failed"
+    (cd "${BACKEND_DIR}" && uv pip compile --quiet --no-header --python-version "$COMPILE_PYTHON_VERSION" --output-file requirements.txt pyproject.toml > /dev/null 2>&1) || fatal "uv pip compile failed"
   else
-    (cd "${BACKEND_DIR}" && uv pip compile --quiet --no-header --frozen --output-file requirements.txt pyproject.toml > /dev/null 2>&1) || fatal "uv pip compile failed"
+    (cd "${BACKEND_DIR}" && uv pip compile --quiet --no-header --output-file requirements.txt pyproject.toml > /dev/null 2>&1) || fatal "uv pip compile failed"
   fi
 
   [ ! -f "${BACKEND_DIR}/requirements.txt" ] && fatal "requirements.txt was not created by uv export"


### PR DESCRIPTION
## Summary

`uv pip compile` does not support the `--frozen` flag — that flag is only valid for `uv lock`, `uv sync`, `uv run`, and `uv export`.

Removing it from both call sites in `build-for-cloudfoundry.sh` so requirements.txt generation succeeds in CI.

## Root Cause

The `--frozen` flag was added in the previous commit to enforce lockfile reproducibility, but was mistakenly applied to `uv pip compile` instead of `uv export`. The `uv pip compile` command resolves from pyproject.toml inputs directly and does not use the uv.lock file, so `--frozen` is not applicable.

## Testing

CI should now pass the `uv pip compile` step.